### PR TITLE
Bugfix: Districts tab breaks Budget tab jQuery

### DIFF
--- a/app/stylesheets/partials/_coding_page.sass
+++ b/app/stylesheets/partials/_coding_page.sass
@@ -55,11 +55,7 @@
     input[type=submit]
       margin-top: 10px
 
-  .tab2
-    display: none
-  .tab3
-    display: none
-  .tab4
+  .tab2, .tab3, .tab4, .tab5, .tab6
     display: none
 
 body #content #main .activity_tree a


### PR DESCRIPTION
You can pull the bugfix for: "Bugfix: Districts tab breaks Budget tab jQuery"

PT story link: http://www.pivotaltracker.com/projects/59773?story_id=4987679
