### PR TITLE
Bugfix: Changed type field as select in code form

### DIFF
--- a/app/controllers/codes_controller.rb
+++ b/app/controllers/codes_controller.rb
@@ -24,6 +24,8 @@ class CodesController < ActiveScaffoldController
     config.columns[:start_date].inplace_edit      = true
     config.columns[:end_date].inplace_edit        = true
     config.columns[:description].inplace_edit     = true
+    config.columns[:type].form_ui                 = :select
+    config.columns[:type].options                 = {:options => ['ActivityCostCategory', 'Beneficiary', 'Code', 'CostCategory', 'Location', 'Mtef', 'Nasa', 'Nha', 'Nsp', 'OtherCostCode', 'OtherCostType']}
   end
 
   # what displays as name when association is expanded for this

--- a/app/stylesheets/partials/_coding_page.sass
+++ b/app/stylesheets/partials/_coding_page.sass
@@ -55,11 +55,7 @@
     input[type=submit]
       margin-top: 10px
 
-  .tab2
-    display: none
-  .tab3
-    display: none
-  .tab4
+  .tab2, .tab3, .tab4, .tab5, .tab6
     display: none
 
 body #content #main .activity_tree a


### PR DESCRIPTION
Bugfix: When Adding a "child" code in the "manage codes" section of the database, gives a Request Failed (code 500, Internal Error)

Please check the comment at PT story: http://www.pivotaltracker.com/projects/59773?story_id=5015740 about this fix.
