### PR TITLE
[fixes #17796191] Fixed settings page styles

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -10,6 +10,7 @@ class OrganizationsController < Reporter::BaseController
       flash[:notice] = "Settings were successfully updated."
       redirect_to dashboard_url
     else
+      flash.now[:error] = "Oops, we couldn't save your changes."
       render :action => :edit
     end
   end

--- a/app/stylesheets/partials/_admin.sass
+++ b/app/stylesheets/partials/_admin.sass
@@ -46,57 +46,6 @@ body.app
     font-size: 11px
     padding: 0 10px 20px 10px
     +pie-clearfix
-  .resources
-    .placer
-      position: relative
-      .form_box
-        background: $lightest-blue + #111111
-        border-top: 1px solid white
-        border-left: 1px solid $lighter-blue
-        border-right: 1px solid $lighter-blue
-        border-bottom: 4px solid $mid-blue
-        padding: 10px 20px
-    .edit_form
-      padding: 0 10px
-    .dashboard_comments, .placer
-      tbody td
-        font-size: 12px
-      ol
-        +horizontal-list
-        #basic
-          float: left
-          width: 70%
-          li
-            width: 48%
-        .buttons
-          float: left
-          font-size: 12px
-          margin-top: 10px
-          width: 25%
-      input[type=text], label
-        width: 90%
-      textarea
-        height: 30px
-        width: 90%
-    .inline-errors
-      color: red
-      margin: -10px
-    .close
-      background: $mid-blue
-      border: 1px solid white
-      color: white
-      float: right
-      font-size: 12px
-      margin-top: 20px
-      padding: 7px 14px 5px
-      text-decoration: none
-      +border-radius
-      &:hover
-        background: white
-        border: 1px solid $lighter-blue
-        color: $mid-blue
-    .cancel_btn
-      margin: 15px 0 0 10px
 
   label
     color: $mid-blue
@@ -320,6 +269,7 @@ body.app
         a
           display: inline-block
           padding: 4px
+
   ul.inline_tab
     +horizontal-list
     border-bottom: 1px solid $light-blue
@@ -338,6 +288,7 @@ body.app
       font-weight: bold
     .incomplete a
       color: #973030
+      
   ul.inline_alt_tab
     +horizontal-list
     border-bottom: 3px solid $mid-blue

--- a/app/stylesheets/partials/_form.sass
+++ b/app/stylesheets/partials/_form.sass
@@ -893,7 +893,7 @@ p.value
   overflow: visible !important
 
 li.input-wrapper
-  input
+  input, input.date_picker[type="text"], .section_form input.date_picker[type="text"]
     width: 179px !important
 
 .input-box

--- a/app/stylesheets/partials/_form.sass
+++ b/app/stylesheets/partials/_form.sass
@@ -104,7 +104,6 @@ input[type="text"], input[type="password"], textarea, select
     select, input[type=text], input[type=password], textarea
       float: left
       margin: 0
-      width: 35%
 
     select
       padding: 4px 4px 3px
@@ -838,6 +837,17 @@ a.tooltip
     -moz-box-shadow: rgba(0,0,0,0.03) 0 -4px 6px inset
     box-shadow: rgba(0,0,0,0.03) 0 -4px 6px inset
 
+  // temporary hack to override basic_form input widths
+  // remove after formtastic refactor is finished
+  select, input[type=text], input[type=password], textarea
+    width: auto
+    &.date_picker
+      background: #fff image_url("icon_calendar2.png") no-repeat 95% 50%
+      width: 80px !important
+      &:hover, &:focus
+        background: #fff image_url("icon_calendar.png") no-repeat 95% 50%
+
+
 .bulk_edit_form
   .section_form
     width: 900px
@@ -881,3 +891,35 @@ a.tooltip
 
 p.value
   overflow: visible !important
+
+li.input-wrapper
+  input
+    width: 179px !important
+
+.input-box
+  float: left
+  position: relative
+  width: 191px
+  +box-shadow(#ccc, 1px, 1px, 2px)
+  +border-bottom-radius(4px)
+  input
+    width: 179px !important
+  &.picker
+    width: 92px
+
+
+.input-errors
+  background: $red
+  clear: both
+  color: #fff
+  font-size: 11px
+  opacity: 0.75
+  padding: 4px 5px 3px
+  +border-bottom-radius(4px)
+  +linear-gradient(color-stops($red, $red - #111))
+  +text-shadow(rgba(0, 0, 0, 0.3), 0, 1px, 0)
+
+.input-hints
+  color: $primary_light - #333
+  font-size: 11px
+  padding-left: 10px

--- a/app/stylesheets/partials/_tables.sass
+++ b/app/stylesheets/partials/_tables.sass
@@ -290,6 +290,7 @@ table.workplan
         +text-shadow(#000, 0, 1px, 0)
       &.hidden
         display: none
+        
   .name
 
     font: normal 13px/1.4 Avenir, Arial, sans-serif

--- a/app/views/layouts/_login_nav.html.haml
+++ b/app/views/layouts/_login_nav.html.haml
@@ -4,21 +4,15 @@
     %ul
       %li
         - link_to edit_profile_path do
-          //= image_tag("icon_profile.png")
           My Profile
       %li
         - link_to "http://hrtapp.tenderapp.com/", :target => "_blank" do
-          //= image_tag("icon_dashboard.png")
           Help
       %li
         - link_to logout_path do
-          //= image_tag("icon_logout.png")
           Sign Out
     %p
       = "#{current_user.email}"
-      // Alternative option to display the user
-      //= "#{current_user.name} (#{current_user.email})"
-
 
   - else
     %ul
@@ -27,5 +21,3 @@
           =image_tag"icon_signin.png"
           Sign in
     %span Have an account?
-
-

--- a/app/views/organizations/_form.html.haml
+++ b/app/views/organizations/_form.html.haml
@@ -32,11 +32,11 @@
     %li.last
       %h2 Basics
       %ul.section_form
-        = f.select :currency, options_for_select(currency_options_for_select, f.object.currency), { :include_blank => true }, :label => "Currency", :required => true, :hint => "You can override the currency for individual projects should you deem it necessary.", :label_html => {:class => 'indented'}
+        = f.select :currency, options_for_select(currency_options_for_select, f.object.currency), { :include_blank => true }, :label => "Default Currency", :required => true, :hint => "You can override the currency for individual projects should you deem it necessary.", :label_html => {:class => 'indented'}, :wrapper_html => {:class => 'input-wrapper'}
 
-        = f.text_field :fiscal_year_start_date, :class => 'date_picker', :label => "Start of Fiscal Year", :required => true, :hint => "The start of the Fiscal Year (FY) that you wish to report in. This may correspond to the FY of your organization, donors, country etc.", :label_html => {:class => 'indented'}
+        = f.text_field :fiscal_year_start_date, :class => 'date_picker', :label => "Start of Fiscal Year", :required => true, :hint => "The start of the Fiscal Year (FY) that you wish to report in. This may correspond to the FY of your organization, donors, country etc.", :label_html => {:class => 'indented'}, :wrapper_html => {:class => 'input-wrapper'}
 
-        = f.text_field :fiscal_year_end_date, :class => 'date_picker', :label => "End of Fiscal Year", :required => true, :hint => "The End of the Fiscal Year", :label_html => {:class => 'indented'}
+        = f.text_field :fiscal_year_end_date, :class => 'date_picker', :label => "End of Fiscal Year", :required => true, :hint => "The End of the Fiscal Year", :label_html => {:class => 'indented'}, :wrapper_html => {:class => 'input-wrapper'}
 
     %li.last
       %h2 Contact Details

--- a/app/views/organizations/_form.html.haml
+++ b/app/views/organizations/_form.html.haml
@@ -27,23 +27,26 @@
     If your fiscal year does not fit any of the above, please
     = link_to "raise a support request", help_link, :target => "_blank"
 
-- f.inputs :class => 'wrap-80 inputs' do
+%fieldset.wrap-80.inputs
+  %ol
+    %li.last
+      %h2 Basics
+      %ul.section_form
+        = f.select :currency, options_for_select(currency_options_for_select, f.object.currency), { :include_blank => true }, :label => "Currency", :required => true, :hint => "You can override the currency for individual projects should you deem it necessary.", :label_html => {:class => 'indented'}
 
-  %li.last
-    %h2 Basics
-    %ul.section_form
-      = f.input :currency, :label => "Default Currency", :label_html => { :class => "indented" }, :as => :select, :collection => currency_options_for_select, :include_blank => true, :hint => "You can override the currency for individual projects should you deem it necessary."
-      = f.input :fiscal_year_start_date, :as => :string, :label => "Start of Fiscal Year", :label_html => { :class => "indented" }, :input_html => {:class => 'date_picker'}, :hint => "The start of the Fiscal Year (FY) that you wish to report in. This may correspond to the FY of your organization, donors, country etc."
-      = f.input :fiscal_year_end_date, :as => :string, :label => "End of Fiscal Year", :label_html => { :class => "indented" }, :input_html => {:class => 'date_picker'}, :hint => "The End of the Fiscal Year"
+        = f.text_field :fiscal_year_start_date, :class => 'date_picker', :label => "Start of Fiscal Year", :required => true, :hint => "The start of the Fiscal Year (FY) that you wish to report in. This may correspond to the FY of your organization, donors, country etc.", :label_html => {:class => 'indented'}
 
-  %li.last
-    %h2 Contact Details
-    %ul.section_form.last
-      = f.input :contact_name, :as => :string, :label_html => { :class => "indented" }, :hint => "The primary contact at your organization that will help the Health Resource Tracker team if there are any questions throughout the process."
-      = f.input :contact_position, :as => :string, :label_html => { :class => "indented" }, :hint => "The position of the contact at your organization."
-      = f.input :contact_phone_number, :as => :string, :label => "Phone number", :label_html => { :class => "indented" }, :hint => "A telephone number that can be used to contact the contact person."
-      = f.input :contact_main_office_phone_number, :as => :string, :label => "Office number", :label_html => { :class => "indented" }, :hint => "The telephone number of the organizations main office."
-      = f.input :contact_office_location, :as => :string, :label => "Office location", :label_html => { :class => "indented" }, :hint => "The geographic location of the office."
+        = f.text_field :fiscal_year_end_date, :class => 'date_picker', :label => "End of Fiscal Year", :required => true, :hint => "The End of the Fiscal Year", :label_html => {:class => 'indented'}
 
-- f.buttons :class => 'wrap-80 buttons push-12' do
-  = f.commit_button "Update Settings", :class => "last", :button_html => { :class => "next" }
+    %li.last
+      %h2 Contact Details
+      %ul.section_form.last
+        = f.text_field :contact_name, :label => "Contact Name", :required => true, :hint => "The primary contact at your organization that will help the Health Resource Tracker team if there are any questions throughout the process.", :wrapper_html => {:class => 'input-wrapper'}, :label_html => {:class => 'indented'}
+        = f.text_field :contact_position, :label => "Contact Position", :required => true, :hint => "The position of the contact at your organization.", :wrapper_html => {:class => 'input-wrapper'}, :label_html => {:class => 'indented'}
+        = f.text_field :contact_phone_number, :label => "Phone number", :required => true, :hint => "A telephone number that can be used to contact the contact person.", :wrapper_html => {:class => 'input-wrapper'}, :label_html => {:class => 'indented'}
+        = f.text_field :contact_main_office_phone_number, :label => "Office number", :required => true, :hint => "The telephone number of the organizations main office.", :wrapper_html => {:class => 'input-wrapper'}, :label_html => {:class => 'indented'}
+        = f.text_field :contact_office_location, :label => "Office location", :required => true, :hint => "The geographic location of the office.", :wrapper_html => {:class => 'input-wrapper'}, :label_html => {:class => 'indented'}
+
+      %fieldset.wrap-80.buttons.push-12
+        %ol
+          = f.submit "Update Settings", :class => "next update"

--- a/app/views/organizations/edit.html.haml
+++ b/app/views/organizations/edit.html.haml
@@ -4,7 +4,7 @@
 
 = render 'getting_started'
 
-= error_messages_for :organization,  :header_message  => nil, :message => "Oops, we couldn't save your changes."
+= render 'shared/base_errors', :resource => @organization
 
-- semantic_form_for @organization, :url => organization_path(@organization), :html => {:class => 'basic_form js_form'} do |f|
+- form_for @organization, :builder => CustomFormBuilder, :url => organization_path(@organization), :html => {:class => 'basic_form js_form'} do |f|
   = render 'form', :f => f

--- a/app/views/shared/_base_errors.html.haml
+++ b/app/views/shared/_base_errors.html.haml
@@ -1,0 +1,5 @@
+- if @organization.errors[:base].present?
+  #errorExplanation.errorExplanation
+    %ul
+      - @organization.errors[:base].each do |error|
+        %li= error

--- a/features/users/reporters/can_edit_settings.feature
+++ b/features/users/reporters/can_edit_settings.feature
@@ -20,10 +20,10 @@ Feature: Reporter can manage data response
       And I should see "<specific_message>"
 
       Examples:
-         | start_date | end_date   | message                              | specific_message                           |
-         | 2010-01-01 | 2010-12-31 | Settings were successfully updated.  | Settings were successfully updated.        |
-         |            | 2010-01-02 | Oops, we couldn't save your changes. | Fiscal year start date can't be blank      |
-         | 123        | 2010-01-02 | Oops, we couldn't save your changes. | Fiscal year start date is not a valid date |
-         | 2010-01-02 |            | Oops, we couldn't save your changes. | Fiscal year end date can't be blank        |
-         | 2010-01-02 | 123        | Oops, we couldn't save your changes. | Fiscal year end date is not a valid date   |
-         | 2010-05-05 | 2010-01-02 | Oops, we couldn't save your changes. | Start date must come before End date.      |
+        | start_date | end_date   | message                              | specific_message                      |
+        | 2010-01-01 | 2010-12-31 | Settings were successfully updated.  | Settings were successfully updated.   |
+        |            | 2010-01-02 | Oops, we couldn't save your changes. | can't be blank                        |
+        | 123        | 2010-01-02 | Oops, we couldn't save your changes. | is not a valid date                   |
+        | 2010-01-02 |            | Oops, we couldn't save your changes. | can't be blank                        |
+        | 2010-01-02 | 123        | Oops, we couldn't save your changes. | is not a valid date                   |
+        | 2010-05-05 | 2010-01-02 | Oops, we couldn't save your changes. | Start date must come before End date. |

--- a/lib/custom_form_builder.rb
+++ b/lib/custom_form_builder.rb
@@ -1,0 +1,63 @@
+class CustomFormBuilder < ActionView::Helpers::FormBuilder
+  # NOTE: maybe this is possible to be defined as method
+  # which will bring more flexibility in the markup
+  ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
+    if html_tag =~ /type="hidden"/ || html_tag =~ /<label/
+      html_tag
+    else
+      error_tag = '<p class="input-errors">' +
+                    [instance.error_message].join(', ') +
+                  '</p>'
+                  "<div class='input-box'>#{html_tag}#{error_tag}</div>"
+    end
+  end
+
+  %w[text_field select collection_select password_field text_area].each do |method_name|
+    define_method(method_name) do |field_name, *args|
+      if args.present? && args[0][:hint].present?
+        hint = @template.content_tag(:p, args[0][:hint], :class => 'input-hints')
+      else
+        hint = ""
+      end
+
+      @template.content_tag(:li, field_label(field_name, *args) +
+                            super + hint, args[0][:wrapper_html])
+    end
+  end
+
+  def check_box(field_name, *args)
+    @template.content_tag(:p, super + " " + field_error(field_name) +
+                          field_label(field_name, *args))
+  end
+
+  def submit(*args)
+    @template.content_tag(:li, super, :class => 'commit')
+  end
+
+  def error_messages(*args)
+    @template.render_error_messages(object, *args)
+  end
+
+  private
+
+  def field_error(field_name)
+    if object.errors.invalid? field_name
+      @template.content_tag(:span,
+          [object.errors.on(field_name)].flatten.first.sub(/^\^/, ''),
+          :class => 'error_message')
+    else
+      ''
+    end
+  end
+
+  def field_label(field_name, *args)
+    options = args.extract_options!
+    label_options = options[:label_html] || {}
+    abbr = label_options[:required] ? '<abbr title="required">*</abbr>' : ''
+    label("#{field_name}#{abbr}", "#{options[:label]}#{abbr}", label_options)
+  end
+
+  def objectify_options(options)
+    super.except(:label, :required, :hint, :label_html, :wrapper_html)
+  end
+end

--- a/public/stylesheets/ui-lightness/jquery-ui-1.8.14.custom.css
+++ b/public/stylesheets/ui-lightness/jquery-ui-1.8.14.custom.css
@@ -62,6 +62,7 @@
 .ui-widget-content { border: 1px solid #dddddd; background: #eeeeee url(images/ui-bg_highlight-soft_100_eeeeee_1x100.png) 50% top repeat-x; color: #333333; }
 .ui-widget-content a { color: #333333; }
 .ui-widget-header { border: 1px solid #e78f08; background: #f6a828 url(images/ui-bg_gloss-wave_35_f6a828_500x100.png) 50% 50% repeat-x; color: #ffffff; font-weight: bold; }
+
 .ui-widget-header a { color: #ffffff; }
 
 /* Interaction states
@@ -296,7 +297,7 @@
  *
  * http://docs.jquery.com/UI/Autocomplete#theming
  */
-.ui-autocomplete { position: absolute; cursor: default; }	
+.ui-autocomplete { position: absolute; cursor: default; }
 
 /* workarounds */
 * html .ui-autocomplete { width:1px; } /* without this, the menu expands to 100% in IE6 */
@@ -361,10 +362,11 @@
 .ui-datepicker .ui-datepicker-title { margin: 0 2.3em; line-height: 1.8em; text-align: center; }
 .ui-datepicker .ui-datepicker-title select { font-size:1em; margin:1px 0; }
 .ui-datepicker select.ui-datepicker-month-year {width: 100%;}
-.ui-datepicker select.ui-datepicker-month, 
+.ui-datepicker select.ui-datepicker-month,
 .ui-datepicker select.ui-datepicker-year { width: 49%;}
 .ui-datepicker table {width: 100%; font-size: .9em; border-collapse: collapse; margin:0 0 .4em; }
 .ui-datepicker th { padding: .7em .3em; text-align: center; font-weight: bold; border: 0;  }
+
 .ui-datepicker td { border: 0; padding: 1px; }
 .ui-datepicker td span, .ui-datepicker td a { display: block; padding: .2em; text-align: right; text-decoration: none; }
 .ui-datepicker .ui-datepicker-buttonpane { background-image: none; margin: .7em 0 0 0; padding:0 .2em; border-left: 0; border-right: 0; border-bottom: 0; }


### PR DESCRIPTION
- [DN] Implemented initial version of custom form builder for settings page
- [DP] new classes and styles for errors and hints
- [DP] date picker restyled
- [DP] inputs defined better, removing old code
- [DN] Fixed custom form builder to allow label_html and wrapper_html tags
- [DN] Added shared partial for base form errors
- [DN] Added stylings to wrapper_html class input-wrapper
