### PR TITLE
[fixes #18146847] submit page shows response status, not request status, 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -174,8 +174,8 @@ class ApplicationController < ActionController::Base
       super
     end
 
-    def latest_request_message(request)
-      "You are now viewing your data for the latest Request: \"<span class='bold'>#{request.name}</span>\""
+    def request_message(request)
+      "You are now viewing your data for the Request: \"<span class='bold'>#{request.name}</span>\""
     end
 
     def not_latest_request_message(request)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,9 +8,10 @@ class UsersController < ApplicationController
     else
       current_user.change_current_response!(params[:id])
       if current_user.current_response_is_latest?
-        flash[:notice] = latest_request_message(current_user.current_response.request)
+        flash[:notice] = request_message(current_user.current_response.request)
       end
     end
+
 
     redirect_back
   end
@@ -18,7 +19,7 @@ class UsersController < ApplicationController
   # set the user's 'current response' to the one associated with the latest Request
   def set_latest_request
     current_user.set_current_response_to_latest!
-    flash[:notice] = latest_request_message(current_user.current_response.request)
+    flash[:notice] = request_message(current_user.current_response.request)
     redirect_back
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -280,7 +280,7 @@ module ApplicationHelper
       if outlay.approved? || outlay.am_approved?
         flash.now[:error] = "Classification for approved activity cannot be changed."
       elsif !outlay.classified?
-        flash.now[:error] = "This #{outlay.class == OtherCost ? "Other Cost" : "Activity"} has not been fully classified.
+        flash.now[:warning] = "This #{outlay.class == OtherCost ? "Other Cost" : "Activity"} has not been fully classified.
                              #{"<a href=\"#\" rel=\"#uncoded_overlay\" class=\"overlay\">Click here</a>
                              to see what still needs to be classified"}"
       end

--- a/app/models/data_request.rb
+++ b/app/models/data_request.rb
@@ -1,6 +1,5 @@
 require 'validators'
 class DataRequest < ActiveRecord::Base
-
   ### Attributes
   attr_accessible :organization_id, :title, :final_review,
                   :start_date, :end_date, :due_date, :budget, :spend,

--- a/app/views/responses/submit.html.haml
+++ b/app/views/responses/submit.html.haml
@@ -13,7 +13,7 @@
     = @response.request.title
   %li
     %span Status:
-    = @response.request.status
+    = @response.status
   %li
     %span Last Submitted:
     = !@response.last_submitted_at.nil? ? l(@response.last_submitted_at, :format => :short) : 'never'


### PR DESCRIPTION
[fixes #18146847] submit page shows response status, not request status, make not classified message a warning, not error
