### PR TITLE
[Fixes #18329055] Sub activities are no longer saved with more than 2 decimals

### DIFF
--- a/app/models/activities/sub_activity.rb
+++ b/app/models/activities/sub_activity.rb
@@ -66,11 +66,11 @@ class SubActivity < Activity
   end
 
   def budget=(amount)
-    write_attribute(:budget, amount)
+    is_number?(amount) ? write_attribute(:budget, amount.to_f.round_with_precision(2)) : write_attribute(:budget, amount)
   end
 
   def spend=(amount)
-    write_attribute(:spend, amount)
+    is_number?(amount) ? write_attribute(:spend, amount.to_f.round_with_precision(2)) : write_attribute(:spend, amount)
   end
 
   def locations # TODO: deprecate

--- a/app/models/activities/sub_activity.rb
+++ b/app/models/activities/sub_activity.rb
@@ -66,11 +66,19 @@ class SubActivity < Activity
   end
 
   def budget=(amount)
-    is_number?(amount) ? write_attribute(:budget, amount.to_f.round_with_precision(2)) : write_attribute(:budget, amount)
+    if is_number?(amount)
+      write_attribute(:budget, amount.to_f.round_with_precision(2))
+    else
+      write_attribute(:budget, amount)
+    end
   end
 
   def spend=(amount)
-    is_number?(amount) ? write_attribute(:spend, amount.to_f.round_with_precision(2)) : write_attribute(:spend, amount)
+    if is_number?(amount)
+      write_attribute(:spend, amount.to_f.round_with_precision(2))
+    else
+      write_attribute(:spend, amount)
+    end
   end
 
   def locations # TODO: deprecate

--- a/spec/models/activities/sub_activity_spec.rb
+++ b/spec/models/activities/sub_activity_spec.rb
@@ -139,30 +139,27 @@ describe SubActivity do
       @sa = Factory.build(:sub_activity, :data_response => @response,
                           :activity => @activity)
     end
-    it "doesn't allow the sub-activity to have a spend with more than two decimal place" do
-      @sa.spend = 10.12345; @sa.save; @sa.reload
-      @sa.spend.to_f.should == 10.12
-    end
 
-    it "doesn't allow the sub-activity to have a budget with more than two decimal place" do
-      @sa.budget = 10.12345; @sa.save; @sa.reload
+    it "doesn't allow the sub-activity to have a spend or budget with more than two decimal places" do
+      @sa.budget = 10.12345
+      @sa.spend = 10.12345
+      @sa.save; @sa.reload
       @sa.budget.to_f.should == 10.12
+      @sa.spend.to_f.should == 10.12
     end
 
     context "rounds up or down" do
       it "if the 3rd decimal place is 5 or larger it rounds up" do
-        @sa.budget = 10.12745; @sa.save; @sa.reload
+        @sa.budget = 10.12745; @sa.spend = 10.12345
+        @sa.save; @sa.reload
         @sa.budget.to_f.should == 10.13
-      end
-
-      it "if the 3rd decimal place is 4 or lower it rounds down" do
-        @sa.budget = 10.12345; @sa.save; @sa.reload
-        @sa.budget.to_f.should == 10.12
+        @sa.spend.to_f.should == 10.12
       end
     end
-    it "works if budget / spend is nil" do
-      @sa.budget = 10.23243336; @sa.spend = nil; @sa.save
-      @sa.budget.should == 10.23
+
+    it "it allows budget / spend to be nil" do
+      @sa.budget = nil; @sa.spend = nil; @sa.save
+      @sa.budget.should == nil
       @sa.spend.should == nil
     end
   end

--- a/spec/models/activities/sub_activity_spec.rb
+++ b/spec/models/activities/sub_activity_spec.rb
@@ -133,34 +133,29 @@ describe SubActivity do
     end
   end
 
-  describe "budget and spend amounts" do
+  describe "#budget= and #spend=" do
     before :each do
       basic_setup_activity
       @sa = Factory.build(:sub_activity, :data_response => @response,
                           :activity => @activity)
     end
 
-    it "doesn't allow the sub-activity to have a spend or budget with more than two decimal places" do
-      @sa.budget = 10.12345
-      @sa.spend = 10.12345
-      @sa.save; @sa.reload
-      @sa.budget.to_f.should == 10.12
-      @sa.spend.to_f.should == 10.12
-    end
-
-    context "rounds up or down" do
-      it "if the 3rd decimal place is 5 or larger it rounds up" do
-        @sa.budget = 10.12745; @sa.spend = 10.12345
-        @sa.save; @sa.reload
-        @sa.budget.to_f.should == 10.13
-        @sa.spend.to_f.should == 10.12
-      end
-    end
-
-    it "it allows budget / spend to be nil" do
-      @sa.budget = nil; @sa.spend = nil; @sa.save
+    it "allows nil value" do
+      @sa.budget = @sa.spend = nil
       @sa.budget.should == nil
       @sa.spend.should == nil
+    end
+
+    it "rounds up to 2 decimals" do
+      @sa.budget = @sa.spend = 10.12745
+      @sa.budget.to_f.should == 10.13
+      @sa.spend.to_f.should == 10.13
+    end
+
+    it "rounds down to 2 decimals" do
+      @sa.budget = @sa.spend = 10.12245
+      @sa.budget.to_f.should == 10.12
+      @sa.spend.to_f.should == 10.12
     end
   end
 

--- a/spec/models/activities/sub_activity_spec.rb
+++ b/spec/models/activities/sub_activity_spec.rb
@@ -133,6 +133,40 @@ describe SubActivity do
     end
   end
 
+  describe "budget and spend amounts" do
+    before :each do
+      basic_setup_activity
+      @sa = Factory.build(:sub_activity, :data_response => @response,
+                          :activity => @activity)
+    end
+    it "doesn't allow the sub-activity to have a spend with more than two decimal place" do
+      @sa.spend = 10.12345; @sa.save; @sa.reload
+      @sa.spend.to_f.should == 10.12
+    end
+
+    it "doesn't allow the sub-activity to have a budget with more than two decimal place" do
+      @sa.budget = 10.12345; @sa.save; @sa.reload
+      @sa.budget.to_f.should == 10.12
+    end
+
+    context "rounds up or down" do
+      it "if the 3rd decimal place is 5 or larger it rounds up" do
+        @sa.budget = 10.12745; @sa.save; @sa.reload
+        @sa.budget.to_f.should == 10.13
+      end
+
+      it "if the 3rd decimal place is 4 or lower it rounds down" do
+        @sa.budget = 10.12345; @sa.save; @sa.reload
+        @sa.budget.to_f.should == 10.12
+      end
+    end
+    it "works if budget / spend is nil" do
+      @sa.budget = 10.23243336; @sa.spend = nil; @sa.save
+      @sa.budget.should == 10.23
+      @sa.spend.should == nil
+    end
+  end
+
   describe "saving sub activity updates the activity" do
     before :each do
       basic_setup_activity


### PR DESCRIPTION
Prevents sub-activities from being saved with more than 2 decimal places
