### PR TITLE
[fixes #19876381] Unstart response when all data deleted

### DIFF
--- a/app/models/activities/other_cost.rb
+++ b/app/models/activities/other_cost.rb
@@ -1,10 +1,14 @@
 class OtherCost < Activity
+  include ResponseStateCallbacks
 
   ### Constants
   FILE_UPLOAD_COLUMNS = %w[project_name description current_budget past_expenditure]
 
   ### Delegates
   delegate :currency, :to => :data_response, :allow_nil => true
+
+  ### Callbacks
+  # also check lib/response_state_callbacks
 
   ### Instance Methods
 

--- a/lib/response_state_callbacks.rb
+++ b/lib/response_state_callbacks.rb
@@ -1,0 +1,24 @@
+module ResponseStateCallbacks
+  def self.included(base_class)
+    base_class.class_eval do
+      # Callbacks
+      after_create  :start_response_if_unstarted
+      after_destroy :unstart_response_if_no_data
+    end
+  end
+
+  private
+
+    def start_response_if_unstarted
+      response.start! if response.unstarted?
+    end
+
+    def unstart_response_if_no_data
+      response.reload # reload for projects_count to update
+      if !response.unstarted? && response.projects.empty? &&
+        response.other_costs.without_a_project.empty? &&
+        response.unstart!
+      end
+
+    end
+end

--- a/spec/models/data_response_spec.rb
+++ b/spec/models/data_response_spec.rb
@@ -59,12 +59,41 @@ describe DataResponse do
       end
     end
 
-    context "all projects are destroyed" do
+    context "first other cost without is created" do
+      it "transitions from unstarted to started when first project is created" do
+        @response.state.should == 'unstarted'
+        Factory(:other_cost, :data_response => @response)
+        @response.reload.state.should == 'started'
+      end
+
+      it "does not transitions back to in progress if it's in rejected state" do
+        @response.state = 'rejected'
+        Factory(:other_cost, :data_response => @response)
+        @response.state.should == 'rejected'
+      end
+    end
+
+    context "no other costs without project" do
+      context "all projects are destroyed" do
+        it "moves the response into unstarted state" do
+          @response.state.should == 'unstarted'
+          project = Factory(:project, :data_response => @response)
+          @response.state.should == 'started'
+          project.destroy
+          @response.reload.state.should == 'unstarted'
+        end
+      end
+    end
+
+    context "other costs without project present" do
       it "moves the response into unstarted state" do
         @response.state.should == 'unstarted'
         project = Factory(:project, :data_response => @response)
+        other_cost = Factory(:other_cost, :data_response => @response)
         @response.state.should == 'started'
         project.destroy
+        @response.reload.state.should == 'started'
+        other_cost.destroy
         @response.reload.state.should == 'unstarted'
       end
     end


### PR DESCRIPTION
- Unstart response when all projects and other costs are deleted
